### PR TITLE
Fix trackingIdentifier property not being assigned after identity retrieval

### DIFF
--- a/Changelogs/1.11.2
+++ b/Changelogs/1.11.2
@@ -1,0 +1,8 @@
+1.11.2 Release notes (2026-01-26)
+================================
+
+Improvements to the 'RingPublishingTracking' module.
+
+### Changes
+
+* Fix for trackingIdentifier property not being set after identity retrieval

--- a/Example/RingPublishingTracking.xcodeproj/project.pbxproj
+++ b/Example/RingPublishingTracking.xcodeproj/project.pbxproj
@@ -1471,7 +1471,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.11.1;
+				MARKETING_VERSION = 1.11.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.RingPublishingTracking-Example.RingPublishingTracking";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1495,7 +1495,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.11.1;
+				MARKETING_VERSION = 1.11.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.RingPublishingTracking-Example.RingPublishingTracking";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/RingPublishingTracking.podspec
+++ b/RingPublishingTracking.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "RingPublishingTracking"
-    s.version      = "1.11.1"
+    s.version      = "1.11.2"
 
     s.summary      = "SDK used to report events from mobile application"
     s.license      = { :type => 'Copyright. Ringier Axel Springer Polska', :file => 'LICENSE' }

--- a/Sources/RingPublishingTracking/Private/RingPublishingTracking+EventsServiceDelegate.swift
+++ b/Sources/RingPublishingTracking/Private/RingPublishingTracking+EventsServiceDelegate.swift
@@ -12,7 +12,7 @@ import Foundation
 extension RingPublishingTracking: EventsServiceDelegate {
 
     func eventsService(_ eventsService: EventsService, retrievedTrackingIdentifier identifier: TrackingIdentifier) {
-        delegate?.ringPublishingTracking(self, didAssignTrackingIdentifier: identifier)
+        trackingIdentifier = identifier
     }
 
     func eventsService(_ eventsService: EventsService, didFailWhileRetrievingTrackingIdentifier error: ServiceError) {


### PR DESCRIPTION
service desk issue: https://jira.ringieraxelspringer.pl/browse/ES_INC-966

Wcześniej delegate był wywoływany bezpośrednio w `eventsService(_:retrievedTrackingIdentifier:)`, ale property `trackingIdentifier` nigdy nie było ustawiane. Teraz ustawiamy `trackingIdentifier = identifier`, a `delegate` jest wywoływany automatycznie przez `didSet` na tej property.
